### PR TITLE
Fix `make arch` to work with parallel make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,14 @@ qcat6: carat/tables/qcatalog/dim6/BASIS
 
 # compile and link the CARAT binaries
 programs: config.carat carat/configure
-	(cd carat && ./configure "$(WITHGMP)" CC="$(CC)" CFLAGS="$(FLAGS)" && make)
+	(cd carat && ./configure $(WITHGMP) CC="$(CC)" CFLAGS="$(CFLAGS)" && make)
 	chmod -R a+rX .
 
 # make suitable links, so that GAP can find the CARAT binaries
 arch: config.carat carat/configure
-	mkdir -p "bin/$(ARCHDIR)"; chmod -R a+rx bin
-	cd "bin/$(ARCHDIR)/"; ln -s ../../carat/bin/* . 
+	if [ -h "bin/$(ARCHDIR)"  ]; then rm "bin/$(ARCHDIR)"; fi
+	mkdir -p "bin/$(ARCHDIR)"
+	ln -sf ../../carat/bin "bin/$(ARCHDIR)"/carat
 
 # dynamic module for setting CARAT_DIR environment variable
 dynmod: src/setcaratdir.c
@@ -68,7 +69,7 @@ dynmod: src/setcaratdir.c
 # clean up everything
 clean: config.carat
 	if [ -d "carat/" ]; then cd carat; make clean; fi
-	if [ -d "bin/$(ARCHDIR)/" ]; then rm -rf "bin/$(ARCHDIR)"/*; fi
+	rm -rf "bin/$(ARCHDIR)"
 	if [ -h "bin/$(ARCHDIR)"  ]; then rm "bin/$(ARCHDIR)"; fi
 
-.PHONY: all clean arch carat qcatalog qcat6
+.PHONY: all arch clean arch carat dynmod programs qcatalog qcat6

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -94,7 +94,7 @@ AvailabilityTest := function()
   # test the existence of a compiled binary; since there are
   # so many, we do not test for all of them, hoping for the best
   path := DirectoriesPackagePrograms( "carat" );
-  if Filename( path, "Z_equiv" ) = fail then
+  if Filename( path, "carat/Z_equiv" ) = fail then
      LogPackageLoadingMessage(PACKAGE_WARNING, "Carat binaries must be compiled" );
      return false;
   fi;

--- a/read.g
+++ b/read.g
@@ -6,7 +6,9 @@
 ##
 
 # location of Carat binaries
-BindGlobal( "CARAT_BIN_DIR", DirectoriesPackagePrograms( "carat" ) );
+BindGlobal( "CARAT_BIN_DIR",
+            List( DirectoriesPackagePrograms( "carat" ),
+                  dir -> Directory( Filename( dir, "carat" ) ) ) );
 
 # directory for temporary files created by interface routines
 BindGlobal( "CARAT_TMP_DIR", DirectoryTemporary() );


### PR DESCRIPTION
... by ensuring it will work correctly regardless of whether carat was already
compiled or not.

Also flag some more Makefile rules as phony.

Resolves #14 (well, I hope, I may have to make some more tweaks)
Closes #16 

Note that this PR could be quite a bit smaller if there was no need for the kernel extension. So I'd really like to get https://github.com/lbfm-rwth/carat/pull/73 finished and merged.